### PR TITLE
add docker-run-notty.sh

### DIFF
--- a/build/docker-run-notty.sh
+++ b/build/docker-run-notty.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+if [ $# -lt 2 ]; then
+  echo "$0 <build> <command> [<args>...]"
+  echo ""
+  echo "example:"
+  echo "  $0 clang ./install.sh"
+  exit 1
+fi
+
+BASE_DIR=$(cd $(dirname $0); pwd)
+docker run \
+  --net=host \
+  -v $BASE_DIR:/var/work \
+  -v $BASE_DIR/../wandbox:/opt/wandbox \
+  -w "/var/work/$1"
+  "melpon/wandbox:$1" "$2" "${@:3}"


### PR DESCRIPTION
README.md 内で使用している `build/docker-run.sh` ですが，`-it` オプションが付いておりシェルスクリプトなど非 TTY で実行する際に問題が生じたため `-it` オプションを用いないものを作成しました．