### PR TITLE
fix crystal-head: run `make clean` and `make crystal` independently

### DIFF
--- a/build/crystal-head/install.sh
+++ b/build/crystal-head/install.sh
@@ -11,7 +11,8 @@ cd crystal/
 git submodule update --recursive --init
 
 # build
-make -j2 clean crystal verbose=1
+make clean verbose=1
+make -j2 crystal verbose=1
 
 # install
 mkdir -p "$PREFIX"


### PR DESCRIPTION
## Problem

Running `./install.sh` of crystal-head sometimes fails due to parallel builds.
The `install.sh` executes `make -j2 clean crystal verbose=1`, however, the two targets cannot to be executed simultaneously. This may be the same problem fixed at [this commit](https://github.com/melpon/wandbox-builder/commit/9c7fee2299ddc404e74ab042e60b0794050a7085).

## Log

``` sh-session
$ sudo ./docker-run.sh crystal-head
root@nek:/var/work/crystal-head# ./install.sh
+++ pwd
++ CURRENT_DIR=/var/work/crystal-head
++++ dirname ./install.sh
+++ cd .
+++ pwd
++ BASE_DIR=/var/work/crystal-head
+ PREFIX=/opt/wandbox/crystal-head
+ cd /root/
+ git clone --depth 1 https://github.com/crystal-lang/crystal.git
Cloning into 'crystal'...
remote: Counting objects: 1337, done.
remote: Compressing objects: 100% (1181/1181), done.
remote: Total 1337 (delta 112), reused 450 (delta 76), pack-reused 0
Receiving objects: 100% (1337/1337), 1.74 MiB | 0 bytes/s, done.
Resolving deltas: 100% (112/112), done.
Checking connectivity... done.
+ cd crystal/
+ git submodule update --recursive --init
+ make -j2 clean crystal verbose=1
Using /usr/bin/llvm-config-3.8 [version=3.8.0]
rm -rf .build
g++ -c  -o src/llvm/ext/llvm_ext.o src/llvm/ext/llvm_ext.cc `/usr/bin/llvm-config-3.8 --cxxflags`
rm -rf ./doc
cc -fPIC    -c -o src/ext/sigfault.o src/ext/sigfault.c
rm -rf src/llvm/ext/llvm_ext.o
rm -rf src/ext/sigfault.o src/ext/libcrystal.a
ar -rcs src/ext/libcrystal.a src/ext/sigfault.o
ar: src/ext/sigfault.o: No such file or directory
Makefile:122: recipe for target 'src/ext/libcrystal.a' failed
make: *** [src/ext/libcrystal.a] Error 1
make: *** Waiting for unfinished jobs....
```

Notice that there is `ar -rcs src/ext/libcrystal.a src/ext/sigfault.o` after `rm -rf src/ext/sigfault.o src/ext/libcrystal.a`.