### PR TITLE
Build nim-head from official nightly

### DIFF
--- a/build/nim-head/docker/Dockerfile
+++ b/build/nim-head/docker/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER melpon <shigemasa7watanabe+docker@gmail.com>
 RUN apt-get update && \
     apt-get install -y \
       build-essential \
+      curl \
       git \
       libncurses5-dev \
       libpcre2-dev \

--- a/build/nim-head/install.sh
+++ b/build/nim-head/install.sh
@@ -6,13 +6,20 @@ PREFIX=/opt/wandbox/nim-head
 
 cd ~/
 
-# get sources
-git clone --depth 1 https://github.com/nim-lang/Nim.git
-cd Nim
-# clones `csources.git`, bootstraps Nim compiler and compiles tools
-sh build_all.sh
+# Download nightly rather than source with git clone.
+# Because nightles are posted only when it passes all testing.
+curl -s https://api.github.com/repos/nim-lang/nightlies/releases/latest | \
+  grep "\"browser_download_url\": \".*-linux\.tar\.xz\"" | \
+  sed -E 's/.*"browser_download_url\": \"([^"]+)\"/\1/' | \
+  wget -qi - -O nim.tar.xz
+tar xf nim.tar.xz
+cd nim*
+# bootstraps Nim compiler and compiles tools
+sh build.sh
+bin/nim c koch
+./koch tools
 
 # install
-./koch install /opt
+sh install.sh ~/tmp
 [ -e "$PREFIX" ] && rm -r "$PREFIX"
-mv /opt/nim "$PREFIX"
+mv ~/tmp "$PREFIX"

--- a/build/nim-head/install.sh
+++ b/build/nim-head/install.sh
@@ -22,4 +22,4 @@ bin/nim c koch
 # install
 sh install.sh ~/tmp
 [ -e "$PREFIX" ] && rm -r "$PREFIX"
-mv ~/tmp "$PREFIX"
+mv ~/tmp/nim "$PREFIX"


### PR DESCRIPTION
This PR download official nightly instead of source code with git clone.
Official nightlies are tested and posted only when it passes all testing.
git clone could sometimes download a broken build depending on timing.