### PR TITLE
Fix nim-head can download nim stable version instead of devel version

### DIFF
--- a/build/nim-head/install.sh
+++ b/build/nim-head/install.sh
@@ -8,8 +8,8 @@ cd ~/
 
 # Download nightly rather than source with git clone.
 # Because nightles are posted only when it passes all testing.
-curl -s https://api.github.com/repos/nim-lang/nightlies/releases/latest | \
-  grep "\"browser_download_url\": \".*-linux\.tar\.xz\"" | \
+curl -s https://api.github.com/repos/nim-lang/nightlies/releases | \
+  grep -m 1 "\"browser_download_url\": \"https://github.com/nim-lang/nightlies/releases/download/\(.*\W\)\?devel\W.*-linux\.tar\.xz\"" | \
   sed -E 's/.*"browser_download_url\": \"([^"]+)\"/\1/' | \
   wget -qi - -O nim.tar.xz
 tar xf nim.tar.xz


### PR DESCRIPTION
This fix nim-head so that it always download devel version.