### PR TITLE
Fix nim-head/install.sh

### DIFF
--- a/build/nim-head/install.sh
+++ b/build/nim-head/install.sh
@@ -9,7 +9,7 @@ cd ~/
 # Download nightly rather than source with git clone.
 # Because nightles are posted only when it passes all testing.
 curl -s https://api.github.com/repos/nim-lang/nightlies/releases | \
-  grep -m 1 "\"browser_download_url\": \"https://github.com/nim-lang/nightlies/releases/download/\(.*\W\)\?devel\W.*-linux\.tar\.xz\"" | \
+  grep -m 1 "\"browser_download_url\": \"https://github.com/nim-lang/nightlies/releases/download/\(.*\W\)\?devel\W.*-linux_x64\.tar\.xz\"" | \
   sed -E 's/.*"browser_download_url\": \"([^"]+)\"/\1/' | \
   wget -qi - -O nim.tar.xz
 tar xf nim.tar.xz


### PR DESCRIPTION
Filename of Nim nightly release has been changed.
This fix install.sh so that it can download lastest release.

Nim team are now creating Linux binaries for x32 and x64 in nightlies. These are built using Holy Build Box and should work with glibc based distros going as far back as CentOS 6. 
Current nim/install.sh build Nim from source code but it should just install prebuilt binaries?
