### PR TITLE
nim-head installs prebuilt binaries

### DIFF
--- a/build/nim-head/install.sh
+++ b/build/nim-head/install.sh
@@ -14,10 +14,6 @@ curl -s https://api.github.com/repos/nim-lang/nightlies/releases | \
   wget -qi - -O nim.tar.xz
 tar xf nim.tar.xz
 cd nim*
-# bootstraps Nim compiler and compiles tools
-sh build.sh
-bin/nim c koch
-./koch tools
 
 # install
 sh install.sh ~/tmp


### PR DESCRIPTION
``build/nim-head/install.sh`` installs prebuilt binary in nim nightly.