### PR TITLE
Install rust-head from prebuilt binary

### DIFF
--- a/build/rust-head/docker/Dockerfile
+++ b/build/rust-head/docker/Dockerfile
@@ -4,13 +4,6 @@ MAINTAINER melpon <shigemasa7watanabe+docker@gmail.com>
 
 RUN apt-get update && \
     apt-get install -y \
-      cmake \
-      curl \
-      g++ \
-      git \
-      libssl-dev \
-      make \
-      pkg-config \
-      python-minimal && \
+      wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/build/rust-head/install.sh
+++ b/build/rust-head/install.sh
@@ -8,30 +8,12 @@ PREFIX=/opt/wandbox/rust-head
 
 cd ~/
 
-git clone --depth 1 https://github.com/rust-lang/rust.git
+wget https://static.rust-lang.org/dist/rust-nightly-x86_64-unknown-linux-gnu.tar.gz
+tar xf rust-nightly-x86_64-unknown-linux-gnu.tar.gz
 
-cd rust
+cd rust-nightly-x86_64-unknown-linux-gnu
 
-# apply patch
-
-# config
-
-cp ./config.toml.example ./config.toml
-sed -i -e 's$#prefix = "/usr/local"$prefix = "'$PREFIX'"$' ./config.toml
-
-# build
-
-./x.py build -j2
 rm -r $PREFIX || true
 mkdir $PREFIX
-# enable install commands:
-#   ./x.py install analysis
-#   ./x.py install cargo
-#   ./x.py install rls
-#   ./x.py install src
-#   ./x.py install src/doc
-#   ./x.py install src/librustc
-#   ./x.py install src/libstd # default
 
-./x.py install # src/libstd
-./x.py install src/librustc
+./install.sh --prefix=$PREFIX --components=rustc,rust-std-x86_64-unknown-linux-gnu


### PR DESCRIPTION
``build/rust-head/install.sh`` in this PR download the official Rust standalone installer(Nightly) and install prebuilt binaries.
I found the URL of that file in https://forge.rust-lang.org/other-installation-methods.html