### PR TITLE
Perl 5 is now on github

### DIFF
--- a/build/perl-head/install.sh
+++ b/build/perl-head/install.sh
@@ -7,7 +7,7 @@ PREFIX=/opt/wandbox/perl-head
 # get sources
 
 cd ~/
-git clone --depth 1 --branch blead git://perl5.git.perl.org/perl.git
+git clone --depth 1 --branch blead https://github.com/Perl/perl5.git perl
 cd perl
 
 # build


### PR DESCRIPTION
This pull request updates the origin of perl-head.
The primary repository Perl 5 is recently migrated to GitHub.

https://www.nntp.perl.org/group/perl.perl5.porters/2019/10/msg256484.html