### PR TITLE
clang-head: Update bootstrap compiler for clang-head build

### DIFF
--- a/build/clang-head/ga-install.sh
+++ b/build/clang-head/ga-install.sh
@@ -6,7 +6,7 @@ apt-get update
 apt-get install -y \
   build-essential \
   clang \
-  clang-6.0 \
+  clang-8 \
   coreutils \
   git \
   libc6-dev-i386 \
@@ -15,7 +15,7 @@ apt-get install -y \
   libmpfr-dev \
   libstdc++-5-dev \
   libtool \
-  python \
+  python3 \
   wget
 
 CMAKE_VERSION="3.16.3"

--- a/build/clang-head/install.sh
+++ b/build/clang-head/install.sh
@@ -31,8 +31,8 @@ mkdir build
 # esac
 cd build
 
-export CC="clang-6.0"
-export CXX="clang++-6.0"
+export CC="clang-8"
+export CXX="clang++-8"
 /usr/local/wandbox/camke-3.16.3/bin/cmake -G "Unix Makefiles" \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=$PREFIX \


### PR DESCRIPTION
`clang-head`のdaily buildがこの３ヶ月ほど止まっていました。
bootstrapに使っているclangを更新すると解決するようです。