### PR TITLE
clang >= 12.0 adds c++2b option

### DIFF
--- a/cattleshed-conf/compilers.py
+++ b/cattleshed-conf/compilers.py
@@ -241,6 +241,14 @@ class Switches(object):
                 'flags': '-std=gnu++2a',
                 'display-name': 'C++2a(GNU)',
             }),
+            ('c++2b', {
+                'flags': ['-std=c++2b'],
+                'display-name': 'C++2b',
+            }),
+            ('gnu++2b', {
+                'flags': '-std=gnu++2b',
+                'display-name': 'C++2b(GNU)',
+            }),
         ]
         return self.resolve_conflicts(pairs, 'std-cxx')
 
@@ -841,6 +849,8 @@ class Compilers(object):
                     switches += ['c++1z', 'gnu++1z']
             if cmpver(cv, '>=', '5.0.0'):
                 switches += ['c++2a', 'gnu++2a']
+            if cmpver(cv, '>=', '12.0.0'):
+                switches += ['c++2b', 'gnu++2b']
             initial_checked += [switches[-1]]
 
             # pedantic


### PR DESCRIPTION
```cpp
#include <type_traits>

enum class E1 {};
enum E2 {};

int main() {
  static_assert(std::is_scoped_enum_v<E1>);
  static_assert(!std::is_scoped_enum_v<E2>);
}
```

https://github.com/llvm/llvm-project/commit/95729f95d803c8e8f4ca3e6767404ec2c0492d53#diff-6630b3ce5d846992565f1f9f1b63d844e36c9ca52658e1ebbd3097686c253a41

https://github.com/llvm/llvm-project/commit/1f1250151f222ba391d05dcc173f4b6c65d05ca2#diff-6630b3ce5d846992565f1f9f1b63d844e36c9ca52658e1ebbd3097686c253a41