### PR TITLE
update ghc-head

### DIFF
--- a/build/ghc-head/docker/Dockerfile
+++ b/build/ghc-head/docker/Dockerfile
@@ -9,12 +9,14 @@ RUN apt-get update && \
       bzip2 \
       g++ \
       git \
-      haskell-platform \
+      libffi-dev \
       libgmp-dev \
       libtool \
       make \
       ncurses-dev \
       python3-minimal \
-      wget && \
+      wget \
+      xz-utils \
+      zlib1g-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/build/ghc-head/install.sh
+++ b/build/ghc-head/install.sh
@@ -2,13 +2,21 @@
 
 . ../init.sh
 
+# haskell stack install
+wget -qO- https://get.haskellstack.org/ | sh
+stack setup
+# configure: error: Alex version 3.2.5 or earlier is required to compile GHC. See GHC issue 19099 for more information.
+stack install alex-3.2.5
+stack install happy
+export PATH=/root/.local/bin:$PATH
+COMPILER_BIN=`stack path --compiler-bin`
+
 PREFIX=/opt/wandbox/ghc-head
-WITH_GHC=/opt/wandbox/ghc-8.4.2/bin/ghc
 
 # get sources
 
 cd ~/
-git clone --recursive git://git.haskell.org/ghc.git
+git clone --recursive https://gitlab.haskell.org/ghc/ghc.git
 
 # install
 
@@ -16,9 +24,9 @@ cd ghc
 cp mk/build.mk.sample mk/build.mk
 sed -i 's/#BuildFlavour = devel2/BuildFlavour = devel2/' mk/build.mk
 ./boot
-./configure --prefix=$PREFIX --with-ghc=$WITH_GHC
+./configure --prefix=$PREFIX GHC="${COMPILER_BIN}/ghc"
 make # -j2 <- insufficient memory
-rm -r $PREFIX/*
+rm -r $PREFIX/* || true
 make install
 rm -r $PREFIX/share
 


### PR DESCRIPTION
ghc のリポジトリが GitLab に引っ越ししてたので変更。
https://gitlab.haskell.org/ghc/ghc
最新の ghc の要求に合わせて Dockerfile と install.sh を修正しました。