### PR TITLE
fix cmake head

### DIFF
--- a/build/cmake-head/docker/Dockerfile
+++ b/build/cmake-head/docker/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
       curl \
       g++ \
       git \
+      libssl-dev \ 
       make && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
libssl-dev が必要になっていたので追加しました

```
-- Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY OPENSSL_INCLUDE_DIR) 
CMake Error at Utilities/cmcurl/CMakeLists.txt:511 (message):
  Could not find OpenSSL.  Install an OpenSSL development package or
  configure CMake with -DCMAKE_USE_OPENSSL=OFF to build without OpenSSL.
```