### PR TITLE
fix swift-head

### DIFF
--- a/build/swift-head/docker/Dockerfile
+++ b/build/swift-head/docker/Dockerfile
@@ -3,9 +3,13 @@ FROM ubuntu:16.04
 MAINTAINER melpon <shigemasa7watanabe+docker@gmail.com>
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y software-properties-common apt-transport-https ca-certificates && \
+    add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-11 main" && \
+    add-apt-repository -y "deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main" && \
+    apt-get update && \
+    apt-get install -y --allow-unauthenticated \
       autoconf \
-      clang \
+      clang-11 \
       cmake \
       git \
       icu-devtools \
@@ -22,9 +26,15 @@ RUN apt-get update && \
       libxml2-dev \
       ninja-build \
       pkg-config \
-      python \
+      python3 \
+      python3-pip \
       swig \
       systemtap-sdt-dev \
       uuid-dev && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 100 \
+      --slave /usr/bin/clang clang /usr/bin/clang-11 && \
+    update-alternatives --install /usr/bin/python python /usr/bin/python3 100 \
+      --slave /usr/bin/pip pip /usr/bin/pip3 && \
+    pip install six && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/build/swift-head/ga-install.sh
+++ b/build/swift-head/ga-install.sh
@@ -3,9 +3,12 @@
 set -ex
 
 apt-get update
+apt-get install -y software-properties-common apt-transport-https ca-certificates
+add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-11 main"    
+apt-get update
 apt-get install -y \
   autoconf \
-  clang \
+  clang-11 \
   cmake \
   git \
   icu-devtools \
@@ -22,9 +25,16 @@ apt-get install -y \
   libxml2-dev \
   ninja-build \
   pkg-config \
-  python \
+  python3 \
+  python3-pip \
   swig \
   systemtap-sdt-dev \
   uuid-dev
+
+update-alternatives --install /usr/bin/clang   clang   /usr/bin/clang-11   100
+update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-11 100
+update-alternatives --install /usr/bin/python python /usr/bin/python3 100 \
+  --slave /usr/bin/pip pip /usr/bin/pip3
+pip install six
 
 ./install.sh


### PR DESCRIPTION
clang / python のバージョン更新
（Docker でのビルドは swift-stdlib-linux-x86_64 がリンカエラーで失敗してしまっていますが、GitHub Actions 版は成功することを確認してます https://github.com/srz-zumix/wandbox-builder/pull/3）