### PR TITLE
ldc-head llvm static link

### DIFF
--- a/build/ldc-head/install.sh
+++ b/build/ldc-head/install.sh
@@ -17,7 +17,10 @@ git submodule update --recursive --init
 mkdir build
 cd build
 
-cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_SHARED=OFF ..
+# for llvm static link workaround
+rm -f /usr/lib/llvm-6.0/lib/*.so* 
+
+cmake -DCMAKE_INSTALL_PREFIX=$PREFIX -DBUILD_SHARED=OFF -DLLVM_IS_SHARED=OFF ..
 
 # apply patches
 # for make in \


### PR DESCRIPTION
```
/opt/wandbox/ldc-head/bin/ldc2: error while loading shared libraries: libLLVM-6.0.so.1: cannot open shared object file: No such file or directory
```

#92 の修正が不完全で libLLVM-6.0.so.1 が本番（および疑似環境）でなくてエラーになってました。
llvm を static link するために、CMake のオプション追加と llvm-6.0 の so を消して llvm-config --shared-mode が static になるようにしました。
詳細→ https://zenn.dev/srz_zumix/scraps/611ba5b55cd08c