### PR TITLE
php build run add libonig-dev

### DIFF
--- a/ga-build/php/run.sh
+++ b/ga-build/php/run.sh
@@ -11,6 +11,7 @@ if [ "$SUBCOMMAND" == "setup" ]; then
     libonig-dev \
     libsqlite3-dev \
     libxml2-dev \
+    libonig-dev \
     pkg-config \
     re2c
   exit 0


### PR DESCRIPTION
php 7.4.16 php 8.0.3 でエラーになる

```
<?php
// This file is a "Hello, world!" in PHP for wandbox.
print("Hello, Wandbox!\n");
// PHP references:
//   http://php.net

```

Run 結果

- php 5.6.40

<img width="820" alt="image" src="https://user-images.githubusercontent.com/716985/151289842-8b99da26-4e45-4f5d-9488-5721f13dc145.png">

- php 7.4.16
<img width="787" alt="image" src="https://user-images.githubusercontent.com/716985/151289757-ce2dc4f6-42ce-45ed-87bd-8490d77ffeb6.png">

- php 8.0.3
<img width="770" alt="image" src="https://user-images.githubusercontent.com/716985/151289783-374801b5-3e01-480e-a3d2-0afed92f9daf.png">
