### PR TITLE
Fix display-compile-command of Rust

### DIFF
--- a/cattleshed-conf/compilers.py
+++ b/cattleshed-conf/compilers.py
@@ -1186,7 +1186,7 @@ class Compilers(object):
                 'switches': [],
                 'initial-checked': [],
                 'display-name': display_name,
-                'display-compile-command': 'rust prog.rs',
+                'display-compile-command': 'rustc prog.rs',
                 'run-command': './prog',
                 'jail-name': 'melpon2-default',
                 'templates': ['rust'],


### PR DESCRIPTION
`display-compile-command` に書かれている `rust` は `rustc` の書き間違いだと思うので修正しました．