### PR TITLE
add perl5.36.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -597,6 +597,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - 5.36.0
           - 5.34.0
           - 5.33.8
           - 5.32.1

--- a/ga-build/perl/resources/perl-5.36.0.tar.gz.sha256
+++ b/ga-build/perl/resources/perl-5.36.0.tar.gz.sha256
@@ -1,0 +1,1 @@
+e26085af8ac396f62add8a533c3a0ea8c8497d836f0689347ac5abd7b7a4e00a  perl-5.36.0.tar.gz


### PR DESCRIPTION
This pull request adds the latest stable version, perl 5.36.0
ref:  https://metacpan.org/release/RJBS/perl-5.36.0