### PR TITLE
Add Ruby 3.4 and bump up other versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -476,8 +476,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 3.3.5
-          - 3.2.5
+          - 3.4.1
+          - 3.3.6
+          - 3.2.6
           - 3.1.6
           - 3.0.7
     runs-on: ubuntu-24.04


### PR DESCRIPTION
先週 Ruby 3.4 がリリースされたので追加しました。同時に、Ruby 3.2 と 3.3 についても更新がリリースされていたのでバージョンを更新しました。

https://www.ruby-lang.org/en/downloads/releases/