### PR TITLE
Add Ruby 4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -485,10 +485,11 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 3.4.1
-          - 3.3.6
-          - 3.2.6
-          - 3.1.6
+          - 4.0.2
+          - 3.4.9
+          - 3.3.11
+          - 3.2.11
+          - 3.1.7
           - 3.0.7
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
This patch added Ruby 4.0.2, also upgraded teeny versions of other Rubies.

https://www.ruby-lang.org/en/downloads/releases/